### PR TITLE
Add afterEntryPublish and afterEntryUpdate event triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ Finally, back to your StoryChief CRAFT CMS channel configuration, fill up your C
 
 :)
 
+## Events
+(Note: this is mostly for developers that know basic PHP and Composer Packages)
+
+`afterEntryPublish` Event, this allows developers to execute custom functionality after a new entry, pushed by Storychief, is saved in Craft.
+
+`afterEntryUpdate` Event, this allows developers to execute custom functionality after an update to an entry, pushed by Storychief, is saved in Craft.
+
+Both events send out a `EntrySaveEvent` with the saved `Entry` object as its property.
 
 
 Brought to you by [StoryChief](https://github.com/Story-Chief/)

--- a/src/events/EntrySaveEvent.php
+++ b/src/events/EntrySaveEvent.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Created by Wouter Van Scharen.
+ * Date: 16.07.19
+ */
+
+namespace storychief\storychiefv3\events;
+
+use yii\base\Event;
+
+class EntrySaveEvent extends Event
+{
+    /**
+     * @var \craft\elements\Entry List of registered component types classes.
+     */
+    public $entry;
+}


### PR DESCRIPTION
Trigger an event after a entry has been either published (newly created) or updated.
Other plugins can then act on these events to execute custom actions.