### PR TITLE
Changes that allow to hook before saving a new entry to the database …

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,56 @@ Finally, back to your StoryChief CRAFT CMS channel configuration, fill up your C
 :)
 
 ## Events
-(Note: this is mostly for developers that know basic PHP and Composer Packages)
 
-`afterEntryPublish` Event, this allows developers to execute custom functionality after a new entry, pushed by Storychief, is saved in Craft.
+Note: this is mostly for developers that know basic PHP and Composer Packages.
 
-`afterEntryUpdate` Event, this allows developers to execute custom functionality after an update to an entry, pushed by Storychief, is saved in Craft.
+### `beforeEntryPublish` and `beforeEntryUpdate` event
+
+This allows developers to execute custom functionality before saving a new or updating an entry, to modify data of a 
+new entry.
+
+```php 
+
+use storychief\storychiefv3\events\EntryPublishEvent;
+
+$this->on('beforeEntryPublish', function (EntryPublishEvent $event) {
+    $payload = $event->payload;
+    $settings = $event->settings;
+    $entry = $event->entry;
+    
+    // Example 1:
+    $entry->sectionId = 2; // BLog
+    $entry->typeId = 2;
+    
+    // Example 2:
+    if ($payload['data']['custom_fields']) {
+        foreach ($payload['data']['custom_fields'] as $customField) {
+            if ($customField['key'] === 'custom_field_name') {                
+                $entry->sectionId = $customField['value'];
+                $entry->typeId = 2;
+            }
+        }
+    }
+});
+
+use storychief\storychiefv3\events\EntryUpdateEvent;
+
+$this->on('beforeEntryUpdate', function (EntryUpdateEvent $event) {
+    // ...
+});
+```
+
+### `afterEntryPublish` event
+
+This allows developers to execute custom functionality after a new entry, pushed by Storychief, is saved in Craft.
+
+### `afterEntryUpdate` event
+
+This allows developers to execute custom functionality after an update to an entry, pushed by Storychief, is saved in Craft.
 
 Both events send out a `EntrySaveEvent` with the saved `Entry` object as its property.
 
+---
 
 Brought to you by [StoryChief](https://github.com/Story-Chief/)
 

--- a/src/controllers/WebhookController.php
+++ b/src/controllers/WebhookController.php
@@ -7,6 +7,8 @@ use yii\web\Controller;
 use craft\elements\Entry;
 use craft\elements\User;
 use storychief\storychiefv3\storychief\FieldTypes\StoryChiefFieldTypeInterface;
+use storychief\storychiefv3\events\EntryPublishEvent;
+use storychief\storychiefv3\events\EntryUpdateEvent;
 use storychief\storychiefv3\events\EntrySaveEvent;
 
 class WebhookController extends Controller
@@ -139,6 +141,18 @@ class WebhookController extends Controller
         // Map all other fields
         $entry = $this->_map($entry);
 
+        // Trigger event to alter the entry before saving
+        $this->trigger(
+            'beforeEntryPublish',
+            new EntryPublishEvent(
+                [
+                    'payload' => $this->payload,
+                    'settings' => $this->settings,
+                    'entry' => $entry,
+                ]
+            )
+        );
+
         Craft::$app->elements->saveElement($entry);
 
         // Trigger after publish event.
@@ -160,6 +174,18 @@ class WebhookController extends Controller
         $entry = $criteria->one();
 
         $entry = $this->_map($entry);
+
+        // Trigger event to alter the entry before saving
+        $this->trigger(
+            'beforeEntryUpdate',
+            new EntryUpdateEvent(
+                [
+                    'payload' => $this->payload,
+                    'settings' => $this->settings,
+                    'entry' => $entry,
+                ]
+            )
+        );
 
         Craft::$app->elements->saveElement($entry);
 

--- a/src/events/EntryPublishEvent.php
+++ b/src/events/EntryPublishEvent.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace storychief\storychiefv3\events;
+
+use craft\elements\Entry;
+use storychief\storychiefv3\models\Settings;
+use yii\base\Event;
+
+class EntryPublishEvent extends Event
+{
+    /** @var array */
+    public $payload;
+
+    /** @var Settings */
+    public $settings;
+
+    /** @var Entry */
+    public $entry;
+}

--- a/src/events/EntryUpdateEvent.php
+++ b/src/events/EntryUpdateEvent.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace storychief\storychiefv3\events;
+
+use craft\elements\Entry;
+use storychief\storychiefv3\models\Settings;
+use yii\base\Event;
+
+class EntryUpdateEvent extends Event
+{
+    /** @var array */
+    public $payload;
+
+    /** @var Settings */
+    public $settings;
+
+    /** @var Entry */
+    public $entry;
+}


### PR DESCRIPTION
This PR allows developers to hook before a new entry is published or updated.

- Alter the sectionId with custom fields
- Map custom fields with Craft fields, categories, tags, assets, etc ...