### PR TITLE
Bugfix/fix error file already exists with s3 volume

### DIFF
--- a/src/storychief/FieldTypes/AssetsStoryChiefFieldType.php
+++ b/src/storychief/FieldTypes/AssetsStoryChiefFieldType.php
@@ -4,8 +4,6 @@ use Craft;
 use  craft\base\Field;
 use craft\elements\Asset;
 use craft\helpers\Assets;
-use craft\base\FlysystemVolume;
-use League\Flysystem\Filesystem;
 
 class AssetsStoryChiefFieldType implements StoryChiefFieldTypeInterface
 {
@@ -27,7 +25,6 @@ class AssetsStoryChiefFieldType implements StoryChiefFieldTypeInterface
             $subPath = $field['defaultUploadLocationSubpath'];
         }
 
-        /** @var FlysystemVolume $volume */
         $volumeID = Craft::$app->getVolumes()->getVolumeByUid($volumeUID)->id;
         $folderID = Craft::$app->assets->getRootFolderByVolumeId($volumeID)->id;
 


### PR DESCRIPTION
The solution looks if the asset already exists. 

- If that asset already exists, the existing asset ID will be returned
- If it doesn't exist, it will be uploaded and the new asset ID will be returned

This change was required, because avoidFilenameConflicts doesn't work with AWS S3 or other filesystem drivers.

Related issue:
https://github.com/Story-Chief/craft-cms-module-storychief-v3/issues/9