### PR TITLE
Support craft cms 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 4.0.0 - 2023-01-05
+## 2.0.0 - 2023-01-05
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,49 +4,79 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 4.0.0 - 2023-01-05
+
+### Added
+
+- Support for craft cms 4
+
 ## 1.0.12 - 2022-07-22
+
 ### Fixed
+
 - Fixed boolean parse
 
 ## 1.0.11 - 2022-05-18
+
 ### Fixed
+
 - Fixed file updates with S3 file system
 
 ## 1.0.10 - 2021-12-27
+
 ### Fixed
+
 - Fixed queries with table prefix (e.g. `craft_`).
+
 ### Added
+
 - Support for Redactor fields
 
 ## 1.0.9 - 2021-08-26
+
 ### Added
+
 - Added beforeEntryPublish and beforeEntryUpdate events which allow altering of the entry before it is saved.
 
 ## 1.0.6 - 2020-08-17
+
 ### Added
+
 - Support for propagation settings: none, language, siteGroup and custom. Previously only all
 
 ## 1.0.5 - 2020-08-11
+
 ### Fixed
+
 - Improved error logging
 
 ## 1.0.4 - 2019-11-12
+
 ### Fixed
+
 - Setting custom field value directly on the element is no longer possible
 
 ## 1.0.3 - 2019-11-12
+
 ### Fixed
+
 - Translations overwrite source article
 
 ## 1.0.2 - 2019-09-18
+
 ### Fixed
+
 - Redirect on settings save
 - Entry field type
 
 ## 1.0.1 - 2019-07-17
+
 ### Added
+
 - Publish events
 
 ## 1.0.0 - 2019-04-16
+
 ### Added
+
 - Initial release

--- a/README.md
+++ b/README.md
@@ -1,13 +1,10 @@
-
 # StoryChief v3 plugin for Craft CMS 3.x
 
 Craft CMS plugin to use with [StoryChief](https://storychief.io).
 
-
 ## Requirements
 
 This plugin requires Craft CMS 3.0.0 or later. (If you are using Craft CMS 2.x, you can find the [right plugin here](https://github.com/Story-Chief/craft-cms-module-storychief).)
-
 
 ## Installation
 
@@ -32,11 +29,11 @@ composer require storychief/craft-cms-v3-storychief
 ./craft install/plugin storychief-v3
 ```
 
-
 ## Activate
+
 To activate the plugin you first need to set up a new Craft CMS channel on your StoryChief admin panel. As soon as you create one, it will give you an **encryption key** .
 
-In your CRAFT CMS, go to your Settings/Plugins and activate your StoryChief plugin. Go to its Settings and fill the encryption key and website URL. 
+In your CRAFT CMS, go to your Settings/Plugins and activate your StoryChief plugin. Go to its Settings and fill the encryption key and website URL.
 
 Save it.
 
@@ -50,10 +47,10 @@ Note: this is mostly for developers that know basic PHP and Composer Packages.
 
 ### `beforeEntryPublish` and `beforeEntryUpdate` event
 
-This allows developers to execute custom functionality before saving a new or updating an entry, to modify data of a 
+This allows developers to execute custom functionality before saving a new or updating an entry, to modify data of a
 new entry.
 
-```php 
+```php
 
 use storychief\storychiefv3\events\EntryPublishEvent;
 
@@ -61,15 +58,15 @@ $this->on('beforeEntryPublish', function (EntryPublishEvent $event) {
     $payload = $event->payload;
     $settings = $event->settings;
     $entry = $event->entry;
-    
+
     // Example 1:
     $entry->sectionId = 2; // BLog
     $entry->typeId = 2;
-    
+
     // Example 2:
     if ($payload['data']['custom_fields']) {
         foreach ($payload['data']['custom_fields'] as $customField) {
-            if ($customField['key'] === 'custom_field_name') {                
+            if ($customField['key'] === 'custom_field_name') {
                 $entry->sectionId = $customField['value'];
                 $entry->typeId = 2;
             }
@@ -97,4 +94,3 @@ Both events send out a `EntrySaveEvent` with the saved `Entry` object as its pro
 ---
 
 Brought to you by [StoryChief](https://github.com/Story-Chief/)
-

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "storychief/craft-cms-v3-storychief",
   "description": "Craft CMS plugin to use with Storychief",
   "type": "craft-plugin",
-  "version": "4.0.0",
+  "version": "2.0.0",
   "keywords": [
     "craft cms 4",
     "cms",

--- a/composer.json
+++ b/composer.json
@@ -1,40 +1,40 @@
 {
-    "name": "storychief/craft-cms-v3-storychief",
-    "description": "Craft CMS plugin to use with Storychief",
-    "type": "craft-plugin",
-    "version": "1.0.12",
-    "keywords": [
-        "craft",
-        "cms",
-        "craftcms",
-        "craft-plugin",
-        "storychief v3"
-    ],
-    "support": {
-        "docs": "https://github.com/Story-Chief/craft-cms-module-storychief",
-        "issues": "https://github.com/Story-Chief/craft-cms-module-storychief/issues"
-    },
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Storychief",
-            "homepage": "https://github.com/Story-Chief/"
-        }
-    ],
-    "require": {
-        "craftcms/cms": "^3.0.0-RC1"
-    },
-    "autoload": {
-        "psr-4": {
-            "storychief\\storychiefv3\\": "src/"
-        }
-    },
-    "extra": {
-        "name": "Storychief v3",
-        "handle": "storychief-v3",
-        "hasCpSettings": true,
-        "hasCpSection": false,
-        "changelogUrl": "https://github.com/Story-Chief/craft-cms-module-storychief/master/CHANGELOG.md",
-        "class": "storychief\\storychiefv3\\StorychiefV3"
+  "name": "storychief/craft-cms-v3-storychief",
+  "description": "Craft CMS plugin to use with Storychief",
+  "type": "craft-plugin",
+  "version": "4.0.0",
+  "keywords": [
+    "craft cms 4",
+    "cms",
+    "craftcms",
+    "craft-plugin",
+    "storychief v3"
+  ],
+  "support": {
+    "docs": "https://github.com/Story-Chief/craft-cms-module-storychief-v3",
+    "issues": "https://github.com/Story-Chief/craft-cms-module-storychief-v3/issues"
+  },
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Storychief",
+      "homepage": "https://github.com/Story-Chief/"
     }
+  ],
+  "require": {
+    "craftcms/cms": "^4.0.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "storychief\\storychiefv3\\": "src/"
+    }
+  },
+  "extra": {
+    "name": "Storychief v3",
+    "handle": "storychief-v3",
+    "hasCpSettings": true,
+    "hasCpSection": false,
+    "changelogUrl": "https://github.com/Story-Chief/craft-cms-module-storychief-v3/master/CHANGELOG.md",
+    "class": "storychief\\storychiefv3\\StorychiefV3"
+  }
 }

--- a/src/StorychiefV3.php
+++ b/src/StorychiefV3.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Storychief v3 plugin for Craft CMS 3.x
  *
@@ -38,16 +39,16 @@ class StorychiefV3 extends Plugin
      * @var StorychiefV3
      */
     public static $plugin;
-    
-    
+
+
     // Public Properties
     // =========================================================================
-    
+
     /**
      * @var string
      */
-    public $schemaVersion = '1.0.0';
-    public $hasCpSettings = true;
+    public string $schemaVersion = '1.0.0';
+    public bool $hasCpSettings = true;
 
     // Public Methods
     // =========================================================================
@@ -93,11 +94,11 @@ class StorychiefV3 extends Plugin
 
     // Protected Methods
     // =========================================================================
-    protected function createSettingsModel()
+    protected function createSettingsModel(): ?\craft\base\Model
     {
         return new Settings();
     }
-    protected function settingsHtml()
+    protected function settingsHtml(): ?string
     {
         $settings = $this->getSettings();
         $settings->validate();

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -12,7 +12,7 @@ class Settings extends Model
     public $mapping = null;
     public $custom_field_definitions = [];
 
-    public function rules()
+    public function rules(): array
     {
         return [
           [['key', 'section', 'entry_type'], 'string'],

--- a/src/variables/StoryChiefVariable.php
+++ b/src/variables/StoryChiefVariable.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace storychief\storychiefv3\variables;
 
 use storychief\storychiefv3\storychief\FieldTypes\StoryChiefFieldTypeInterface;
@@ -89,8 +90,8 @@ class StoryChiefVariable
         foreach ($allFields as $item) {
             if (in_array($item['type'], $supportedTypes, true)) {
                 $options[] = [
-                  'label' => $item['label'],
-                  'value' => $item['name'],
+                    'label' => $item['label'],
+                    'value' => $item['name'],
                 ];
             }
         }
@@ -136,7 +137,7 @@ class StoryChiefVariable
         $entryType = \Craft::$app->sections->getEntryTypeById($entryTypeID);
 
 
-        $fields = $entryType->getFieldLayout()->getFields();
+        $fields = $entryType->getFieldLayout()->getCustomFields();
 
         foreach ($fields as $field) {
             $fieldDefinition = $field->getAttributes(['id', 'name', 'handle']);


### PR DESCRIPTION
## Changes
Some changes to support craft 4 
This is working, but tests are still basic 
Next major version is 2.0.0 
Will support craft > 4.0.0


<img width="1246" alt="Screenshot 2023-01-05 at 14 04 14" src="https://user-images.githubusercontent.com/48244596/210786613-119b79fa-349c-4835-917b-133bb9a57d17.png">

## Before merging 
Testing is needed ( Orabi ) 

## Plugin Name 
Will be changed after craft 4 support is added if we decide to do so 
change the plugin name from `craft-cms-storychief-v3` to `craft-cms-storychief`