### PR TITLE
Upgrade to Craft 5

### DIFF
--- a/.craftplugin
+++ b/.craftplugin
@@ -1,7 +1,7 @@
 {
   "pluginName": "Storychief v3",
-  "pluginDescription": "Craft CMS plugin to use with Storychief ( Craft cms ^4.0.0 )",
-  "pluginVersion": "2.0.0",
+  "pluginDescription": "Craft CMS plugin to use with Storychief",
+  "pluginVersion": "1.0.12",
   "pluginAuthorName": "Storychief",
   "pluginVendorName": "storychief",
   "pluginAuthorUrl": "https://github.com/Story-Chief/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,79 +4,53 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 2.0.0 - 2023-01-05
-
+## 1.0.13 - 2024-11-12
 ### Added
-
-- Support for craft cms 4
+- Added support for Craft CMS 5
 
 ## 1.0.12 - 2022-07-22
-
 ### Fixed
-
 - Fixed boolean parse
 
 ## 1.0.11 - 2022-05-18
-
 ### Fixed
-
 - Fixed file updates with S3 file system
 
 ## 1.0.10 - 2021-12-27
-
 ### Fixed
-
 - Fixed queries with table prefix (e.g. `craft_`).
-
 ### Added
-
 - Support for Redactor fields
 
 ## 1.0.9 - 2021-08-26
-
 ### Added
-
 - Added beforeEntryPublish and beforeEntryUpdate events which allow altering of the entry before it is saved.
 
 ## 1.0.6 - 2020-08-17
-
 ### Added
-
 - Support for propagation settings: none, language, siteGroup and custom. Previously only all
 
 ## 1.0.5 - 2020-08-11
-
 ### Fixed
-
 - Improved error logging
 
 ## 1.0.4 - 2019-11-12
-
 ### Fixed
-
 - Setting custom field value directly on the element is no longer possible
 
 ## 1.0.3 - 2019-11-12
-
 ### Fixed
-
 - Translations overwrite source article
 
 ## 1.0.2 - 2019-09-18
-
 ### Fixed
-
 - Redirect on settings save
 - Entry field type
 
 ## 1.0.1 - 2019-07-17
-
 ### Added
-
 - Publish events
 
 ## 1.0.0 - 2019-04-16
-
 ### Added
-
 - Initial release

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-# StoryChief v3 plugin for Craft CMS 4.x
+# StoryChief v3 plugin for Craft CMS 5.x
 
 Craft CMS plugin to use with [StoryChief](https://storychief.io).
 
 ## Requirements
 
-This plugin requires Craft CMS 4.0.0 or later. (If you are using Craft CMS 3.x, you can find the [right plugin here](https://github.com/Story-Chief/craft-cms-module-storychief-v3/releases/tag/v1.0.12)
+This plugin requires Craft CMS 5.0.0 or later. (If you are using Craft CMS 2.x, you can find the [right plugin here](https://github.com/Story-Chief/craft-cms-module-storychief).)
+
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -2,9 +2,9 @@
   "name": "storychief/craft-cms-v3-storychief",
   "description": "Craft CMS plugin to use with Storychief",
   "type": "craft-plugin",
-  "version": "2.0.0",
+  "version": "1.0.13",
   "keywords": [
-    "craft cms 4",
+    "craft",
     "cms",
     "craftcms",
     "craft-plugin",
@@ -22,7 +22,7 @@
     }
   ],
   "require": {
-    "craftcms/cms": "^4.0.0"
+    "craftcms/cms": "^5.0.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/StorychiefV3.php
+++ b/src/StorychiefV3.php
@@ -12,6 +12,7 @@
 namespace storychief\storychiefv3;
 
 use Craft;
+use craft\base\Model;
 use yii\base\Event;
 use craft\base\Plugin;
 use craft\services\Plugins;
@@ -94,10 +95,11 @@ class StorychiefV3 extends Plugin
 
     // Protected Methods
     // =========================================================================
-    protected function createSettingsModel(): ?\craft\base\Model
+    protected function createSettingsModel(): ?Model
     {
         return new Settings();
     }
+
     protected function settingsHtml(): ?string
     {
         $settings = $this->getSettings();

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -15,8 +15,8 @@ class Settings extends Model
     public function rules(): array
     {
         return [
-          [['key', 'section', 'entry_type'], 'string'],
-          [['key', 'section', 'entry_type'], 'required'],
-    ];
+            [['key', 'section', 'entry_type'], 'string'],
+            [['key', 'section', 'entry_type'], 'required'],
+        ];
     }
 }

--- a/src/storychief/FieldTypes/AssetsStoryChiefFieldType.php
+++ b/src/storychief/FieldTypes/AssetsStoryChiefFieldType.php
@@ -7,7 +7,7 @@ use craft\helpers\Assets;
 
 class AssetsStoryChiefFieldType implements StoryChiefFieldTypeInterface
 {
-    public function supportedStorychiefFieldTypes()
+    public function supportedStorychiefFieldTypes(): array
     {
         return [
             'featured_image',
@@ -15,11 +15,11 @@ class AssetsStoryChiefFieldType implements StoryChiefFieldTypeInterface
         ];
     }
 
-    public function prepFieldData(Field $field, $fieldData)
+    public function prepFieldData(Field $field, $fieldData): array
     {
         if ($field->restrictLocation) {
-            $volumeUID = explode(':', $field->restrictedLocationSource)[1];
-            $subPath = $field['restrictedLocationSubpath'];
+            $volumeUID = explode(':', $field->singleUploadLocationSource)[1];
+            $subPath = $field['singleUploadLocationSubpath'];
         } else {
             $volumeUID = explode(':', $field->defaultUploadLocationSource)[1];
             $subPath = $field['defaultUploadLocationSubpath'];
@@ -28,23 +28,21 @@ class AssetsStoryChiefFieldType implements StoryChiefFieldTypeInterface
         $volumeID = Craft::$app->getVolumes()->getVolumeByUid($volumeUID)->id;
         $folderID = Craft::$app->assets->getRootFolderByVolumeId($volumeID)->id;
 
-        $preppedData = [];        
+        $preppedData = [];
 
         // get remote image and store in temp path
         $imageInfo = pathinfo($fieldData);
-        $tempPath = Craft::$app->getPath()->getTempPath() . DIRECTORY_SEPARATOR . $imageInfo['basename'];
+        $tempPath = Craft::$app->getPath()->getTempPath().DIRECTORY_SEPARATOR.$imageInfo['basename'];
         $filename = Assets::prepareAssetName($imageInfo['basename']);
 
         // Look if the filename already exists and so the existing asset
-        $asset = Asset::find()->where(
-            [
-                'assets.volumeID' => $volumeID, 
-                'assets.folderId' => $folderID, 
-                'assets.filename' => $filename
-            ]
-        )->one();
+        $asset = Asset::find()->where([
+            'assets.volumeID' => $volumeID,
+            'assets.folderId' => $folderID,
+            'assets.filename' => $filename,
+        ])->one();
 
-        if (!$asset) {            
+        if (! $asset) {
             file_put_contents($tempPath, fopen($fieldData, 'r'));
 
             $asset = new Asset();
@@ -55,7 +53,7 @@ class AssetsStoryChiefFieldType implements StoryChiefFieldTypeInterface
             $asset->folderPath = $subPath;
             $asset->avoidFilenameConflicts = true;
 
-            if (!Craft::$app->elements->saveElement($asset)) {
+            if (! Craft::$app->elements->saveElement($asset)) {
                 $asset = null; // The response failed
             }
         }

--- a/src/storychief/FieldTypes/CategoriesStoryChiefFieldType.php
+++ b/src/storychief/FieldTypes/CategoriesStoryChiefFieldType.php
@@ -1,18 +1,18 @@
 <?php namespace storychief\storychiefv3\storychief\FieldTypes;
 
 use Craft;
-use craft\helpers\Db;
-use  craft\base\Field;
+use craft\base\Field;
 use craft\elements\Category;
+use craft\helpers\Db;
 
 class CategoriesStoryChiefFieldType implements StoryChiefFieldTypeInterface
 {
-    public function supportedStorychiefFieldTypes()
+    public function supportedStorychiefFieldTypes(): array
     {
         return [
             'categories',
             'select',
-            'checkbox'
+            'checkbox',
         ];
     }
 
@@ -20,14 +20,13 @@ class CategoriesStoryChiefFieldType implements StoryChiefFieldTypeInterface
     {
         $preppedData = [];
         $categoryGroupUID = str_replace('group:', '', $field->source);
-        $categoryGroup =  (new \craft\db\Query())
-        ->select(['id'])
-        ->from('{{%categorygroups}}')
-        ->where(['uid' => $categoryGroupUID])
-        ->one();
+        $categoryGroup = (new \craft\db\Query())
+            ->select(['id'])
+            ->from('{{%categorygroups}}')
+            ->where(['uid' => $categoryGroupUID])
+            ->one();
 
         $categoryGroupID = $categoryGroup['id'];
-
 
         $limit = count($fieldData);
         if (isset($field->settings['limit']) && $field->settings['limit']) {
@@ -42,8 +41,7 @@ class CategoriesStoryChiefFieldType implements StoryChiefFieldTypeInterface
             $criteria->title = Db::escapeParam($categoryName);
             $category = $criteria->one();
 
-
-            if (!$category) {
+            if (! $category) {
                 $category = new Category();
                 $category->groupId = $categoryGroupID;
                 $category->title = $categoryName;

--- a/src/storychief/FieldTypes/CheckboxesStoryChiefFieldType.php
+++ b/src/storychief/FieldTypes/CheckboxesStoryChiefFieldType.php
@@ -4,22 +4,22 @@ use  craft\base\Field;
 
 class CheckboxesStoryChiefFieldType implements StoryChiefFieldTypeInterface
 {
-    public function supportedStorychiefFieldTypes()
+    public function supportedStorychiefFieldTypes(): array
     {
         return [
-            'checkbox'
+            'checkbox',
         ];
     }
 
-    public function prepFieldData(Field $field, $fieldData)
+    public function prepFieldData(Field $field, $fieldData): ?array
     {
         $preppedData = [];
 
         if (empty($fieldData)) {
             return $preppedData;
         }
-        if (!is_array($fieldData)) {
-            $fieldData = array($fieldData);
+        if (! is_array($fieldData)) {
+            $fieldData = [$fieldData];
         }
 
         $options = $field->options;

--- a/src/storychief/FieldTypes/DropdownStoryChiefFieldType.php
+++ b/src/storychief/FieldTypes/DropdownStoryChiefFieldType.php
@@ -1,17 +1,17 @@
 <?php namespace storychief\storychiefv3\storychief\FieldTypes;
 
-use  craft\base\Field;
+use craft\base\Field;
 
 class DropdownStoryChiefFieldType implements StoryChiefFieldTypeInterface
 {
-    public function supportedStorychiefFieldTypes()
+    public function supportedStorychiefFieldTypes(): array
     {
         return [
-            'select'
+            'select',
         ];
     }
 
-    public function prepFieldData(Field $field, $fieldData)
+    public function prepFieldData(Field $field, $fieldData): ?string
     {
         $preppedData = null;
 

--- a/src/storychief/FieldTypes/EntriesStoryChiefFieldType.php
+++ b/src/storychief/FieldTypes/EntriesStoryChiefFieldType.php
@@ -1,13 +1,12 @@
 <?php namespace storychief\storychiefv3\storychief\FieldTypes;
 
-use Craft;
-use  craft\base\Field;
-use craft\helpers\Db;
+use craft\base\Field;
 use craft\elements\Entry;
+use craft\helpers\Db;
 
 class EntriesStoryChiefFieldType implements StoryChiefFieldTypeInterface
 {
-    public function supportedStorychiefFieldTypes()
+    public function supportedStorychiefFieldTypes(): array
     {
         return [
             'select',
@@ -21,8 +20,8 @@ class EntriesStoryChiefFieldType implements StoryChiefFieldTypeInterface
         if (empty($fieldData)) {
             return $preppedData;
         }
-        if (!is_array($fieldData)) {
-            $fieldData = array($fieldData);
+        if (! is_array($fieldData)) {
+            $fieldData = [$fieldData];
         }
 
         // Find existing

--- a/src/storychief/FieldTypes/LightswitchStoryChiefFieldType.php
+++ b/src/storychief/FieldTypes/LightswitchStoryChiefFieldType.php
@@ -5,18 +5,17 @@ use storychief\storychiefv3\storychief\Helpers\StoryChiefHelper;
 
 class LightswitchStoryChiefFieldType implements StoryChiefFieldTypeInterface
 {
-    public function supportedStorychiefFieldTypes()
+    public function supportedStorychiefFieldTypes(): array
     {
         return [
             'select',
             'radio',
-            'checkbox'
+            'checkbox',
         ];
     }
 
-    public function prepFieldData(Field $field, $fieldData)
+    public function prepFieldData(Field $field, $fieldData): bool
     {
-        $preppedData = StoryChiefHelper::parseBoolean($fieldData);
-        return $preppedData;
+        return StoryChiefHelper::parseBoolean($fieldData);
     }
 }

--- a/src/storychief/FieldTypes/MultiSelectStoryChiefFieldType.php
+++ b/src/storychief/FieldTypes/MultiSelectStoryChiefFieldType.php
@@ -1,25 +1,25 @@
 <?php namespace storychief\storychiefv3\storychief\FieldTypes;
 
-use  craft\base\Field;
+use craft\base\Field;
 
 class MultiSelectStoryChiefFieldType implements StoryChiefFieldTypeInterface
 {
-    public function supportedStorychiefFieldTypes()
+    public function supportedStorychiefFieldTypes(): array
     {
         return [
-            'select'
+            'select',
         ];
     }
 
-    public function prepFieldData(Field $field, $fieldData)
+    public function prepFieldData(Field $field, $fieldData): array
     {
         $preppedData = [];
 
         if (empty($fieldData)) {
             return $preppedData;
         }
-        if (!is_array($fieldData)) {
-            $fieldData = array($fieldData);
+        if (! is_array($fieldData)) {
+            $fieldData = [$fieldData];
         }
 
         $options = $field->options;

--- a/src/storychief/FieldTypes/PlainTextStoryChiefFieldType.php
+++ b/src/storychief/FieldTypes/PlainTextStoryChiefFieldType.php
@@ -1,21 +1,20 @@
 <?php namespace storychief\storychiefv3\storychief\FieldTypes;
 
-use  craft\base\Field;
+use craft\base\Field;
 
 class PlainTextStoryChiefFieldType implements StoryChiefFieldTypeInterface
 {
-    public function supportedStorychiefFieldTypes()
+    public function supportedStorychiefFieldTypes(): array
     {
         return [
             'text',
             'textarea',
-            'excerpt'
+            'excerpt',
         ];
     }
 
-    public function prepFieldData(Field $field, $fieldData)
+    public function prepFieldData(Field $field, $fieldData): ?string
     {
-        $preppedData = $fieldData;
-        return $preppedData;
+        return $fieldData;
     }
 }

--- a/src/storychief/FieldTypes/RadioButtonsStoryChiefFieldType.php
+++ b/src/storychief/FieldTypes/RadioButtonsStoryChiefFieldType.php
@@ -1,17 +1,17 @@
 <?php namespace storychief\storychiefv3\storychief\FieldTypes;
 
-use  craft\base\Field;
+use craft\base\Field;
 
 class RadioButtonsStoryChiefFieldType implements StoryChiefFieldTypeInterface
 {
-    public function supportedStorychiefFieldTypes()
+    public function supportedStorychiefFieldTypes(): array
     {
         return [
-            'radio'
+            'radio',
         ];
     }
 
-    public function prepFieldData(Field $field, $fieldData)
+    public function prepFieldData(Field $field, $fieldData): ?string
     {
         $preppedData = null;
 

--- a/src/storychief/FieldTypes/RichTextStoryChiefFieldType.php
+++ b/src/storychief/FieldTypes/RichTextStoryChiefFieldType.php
@@ -1,22 +1,21 @@
 <?php namespace storychief\storychiefv3\storychief\FieldTypes;
 
-use  craft\base\Field;
+use craft\base\Field;
 
 class RichTextStoryChiefFieldType implements StoryChiefFieldTypeInterface
 {
-    public function supportedStorychiefFieldTypes()
+    public function supportedStorychiefFieldTypes(): array
     {
         return [
             'richtext',
             'text',
             'textarea',
-            'excerpt'
+            'excerpt',
         ];
     }
 
-    public function prepFieldData(Field $field, $fieldData)
+    public function prepFieldData(Field $field, $fieldData): ?string
     {
-        $preppedData = $fieldData;
-        return $preppedData;
+        return $fieldData;
     }
 }

--- a/src/storychief/FieldTypes/TagsStoryChiefFieldType.php
+++ b/src/storychief/FieldTypes/TagsStoryChiefFieldType.php
@@ -2,42 +2,42 @@
 
 use Craft;
 use craft\base\Field;
-use craft\helpers\Db;
 use craft\elements\Tag;
+use craft\helpers\Db;
 
 class TagsStoryChiefFieldType implements StoryChiefFieldTypeInterface
 {
-    public function supportedStorychiefFieldTypes()
+    public function supportedStorychiefFieldTypes(): array
     {
         return [
             'tags',
             'select',
-            'checkbox'
+            'checkbox',
         ];
     }
 
-    public function prepFieldData(Field $field, $fieldData)
+    public function prepFieldData(Field $field, $fieldData): array
     {
         $preppedData = [];
 
         if (empty($fieldData)) {
             return $preppedData;
         }
-        if (!is_array($fieldData)) {
-            $fieldData = array($fieldData);
+
+        if (! is_array($fieldData)) {
+            $fieldData = [$fieldData];
         }
 
         $source = $field->source;
-        list($type, $groupUid) = explode(':', $source);
+        [$type, $groupUid] = explode(':', $source);
 
-        $tagGroup =  (new \craft\db\Query())
-        ->select(['id'])
-        ->from('{{%taggroups}}')
-        ->where(['uid' => $groupUid])
-        ->one();
+        $tagGroup = (new \craft\db\Query())
+            ->select(['id'])
+            ->from('{{%taggroups}}')
+            ->where(['uid' => $groupUid])
+            ->one();
 
         $groupId = $tagGroup['id'];
-
 
         // Find existing
         foreach ($fieldData as $tagName) {

--- a/src/storychief/Helpers/StoryChiefHelper.php
+++ b/src/storychief/Helpers/StoryChiefHelper.php
@@ -25,7 +25,7 @@ use storychief\storychiefv3\storychief\FieldTypes\TagsStoryChiefFieldType;
 
 class StoryChiefHelper
 {
-    public static function parseBoolean($value)
+    public static function parseBoolean($value): bool
     {
         if (is_array($value)) {
             $value = array_shift($value);
@@ -46,7 +46,6 @@ class StoryChiefHelper
             $result = true;
         }
 
-
         if (strtolower($value) === Craft::t('app', 'no')) {
             $result = false;
         }
@@ -62,9 +61,9 @@ class StoryChiefHelper
         return $result;
     }
 
-    public static function getStoryChiefFieldClass($field)
+    public static function getStoryChiefFieldClass($field): ?string
     {
-        if (!$field) {
+        if (! $field) {
             return null;
         }
 

--- a/src/variables/StoryChiefVariable.php
+++ b/src/variables/StoryChiefVariable.php
@@ -8,10 +8,10 @@ use craft;
 
 class StoryChiefVariable
 {
-    public function getStoryChiefSections()
+    public function getStoryChiefSections(): array
     {
         $sections = [];
-        foreach (\Craft::$app->sections->getAllSections() as $section) {
+        foreach ((new craft\services\Entries())->getAllSections() as $section) {
             if ($section->type === 'channel') {
                 $sections[] = [
                     'label' => $section->name,
@@ -23,43 +23,43 @@ class StoryChiefVariable
         return $sections;
     }
 
-    public function getAllStoryChiefFields()
+    public function getAllStoryChiefFields(): array
     {
         $default_fields = [
             [
                 'label' => 'Content',
-                'name'  => 'content',
-                'type'  => 'textarea',
+                'name' => 'content',
+                'type' => 'textarea',
             ],
             [
                 'label' => 'Excerpt',
-                'name'  => 'excerpt',
-                'type'  => 'textarea',
+                'name' => 'excerpt',
+                'type' => 'textarea',
             ],
             [
                 'label' => 'Featured image',
-                'name'  => 'featured_image',
-                'type'  => 'image',
+                'name' => 'featured_image',
+                'type' => 'image',
             ],
             [
                 'label' => 'Tags',
-                'name'  => 'tags',
-                'type'  => 'tags',
+                'name' => 'tags',
+                'type' => 'tags',
             ],
             [
                 'label' => 'Categories',
-                'name'  => 'categories',
-                'type'  => 'categories',
+                'name' => 'categories',
+                'type' => 'categories',
             ],
             [
                 'label' => 'SEO Title',
-                'name'  => 'seo_title',
-                'type'  => 'text',
+                'name' => 'seo_title',
+                'type' => 'text',
             ],
             [
                 'label' => 'SEO Description',
-                'name'  => 'seo_description',
-                'type'  => 'textarea',
+                'name' => 'seo_description',
+                'type' => 'textarea',
             ],
         ];
 
@@ -74,12 +74,12 @@ class StoryChiefVariable
         $field = \Craft::$app->fields->getFieldByHandle($fieldHandle);
         $class = StoryChiefHelper::getStoryChiefFieldClass($field);
 
-        if (!$class || !class_exists($class)) {
+        if (! $class || ! class_exists($class)) {
             return null;
         }
 
         $scField = new $class();
-        if (!$scField instanceof StoryChiefFieldTypeInterface) {
+        if (! $scField instanceof StoryChiefFieldTypeInterface) {
             return null;
         }
 
@@ -99,7 +99,7 @@ class StoryChiefVariable
         return empty($options) ? null : $options;
     }
 
-    public function getStoryChiefAuthorOptions()
+    public function getStoryChiefAuthorOptions(): array
     {
         return [
             [
@@ -113,14 +113,14 @@ class StoryChiefVariable
             [
                 'label' => 'Import or create new',
                 'value' => 'create',
-            ]
+            ],
         ];
     }
 
-    public function getStoryChiefEntryTypes($sectionID)
+    public function getStoryChiefEntryTypes($sectionID): array
     {
         $entryTypes = [];
-        foreach (\Craft::$app->sections->getEntryTypesBySectionId($sectionID) as $entryType) {
+        foreach (\Craft::$app->entries->getEntryTypesBySectionId($sectionID) as $entryType) {
             $entryTypes[] = [
                 'label' => $entryType->name,
                 'value' => $entryType->id,
@@ -130,12 +130,11 @@ class StoryChiefVariable
         return $entryTypes;
     }
 
-    public function getStoryChiefContentFields($entryTypeID)
+    public function getStoryChiefContentFields($entryTypeID): array
     {
         $fieldDefinitions = [];
 
-        $entryType = \Craft::$app->sections->getEntryTypeById($entryTypeID);
-
+        $entryType = \Craft::$app->entries->getEntryTypeById($entryTypeID);
 
         $fields = $entryType->getFieldLayout()->getCustomFields();
 
@@ -144,6 +143,7 @@ class StoryChiefVariable
             $fieldDefinition['required'] = $field->required === '1';
             $fieldDefinitions[] = $fieldDefinition;
         }
+
         return $fieldDefinitions;
     }
 }


### PR DESCRIPTION
# Description
This PR upgrades the plugin to be able to deal with version 5 of the Craft CMS. 

TODO: still an issue adding the new plugin via composer

# Testing instructions
## Setup
### CMS
Set up Craft CMS 5 (see [testing instructions in Developer environment](https://github.com/Story-Chief/Developer-Docker-Environment/tree/feature/upgrade-to-craft-5/cms/craft5))

### Plugin:
In the fresh Craft CMS v5, add the storychief plugin by adding the following line to the `require` array in composer.json:
```
    "storychief/craft-cms-v3-storychief": "dev-feature/upgrade-to-craft5-002"
```
Then install the composer packages with `composer i` - or if you're using `ddev` it's: 
```
ddev composer i
```

If you encounter an error, remove the existing composer.lock file and run the `ddev composer i` command again.

This will add the version on the current branch.

## Testing
- Connect the plugin (if ngrok is needed and you're using `ddev`, you can run `ddev share` to launch ngrok from the craft app.
- publish article
- Test multiple languages
- Test custom fields